### PR TITLE
fix delete local backup

### DIFF
--- a/src/backup.sh
+++ b/src/backup.sh
@@ -133,7 +133,7 @@ delete () {
       --older-than "${BACKUP_RETENTION_DAYS}d" \
       "$target"
   else
-    find $target* -delete -type f -mtime $BACKUP_RETENTION_DAYS
+    find $target* -type f -mtime $BACKUP_RETENTION_DAYS -exec rm -rf '{}' ';'
   fi
 }
 


### PR DESCRIPTION
Changed

find $target* -delete -type f -mtime $BACKUP_RETENTION_DAYS

to

find $target* -type f -mtime $BACKUP_RETENTION_DAYS -exec rm -rf '{}' ';'

Now it deletes files correctly, the older way deletes everything.