### PR TITLE
Disable healthcheck in swarm test

### DIFF
--- a/test/swarm/docker-compose.yml
+++ b/test/swarm/docker-compose.yml
@@ -43,6 +43,8 @@ services:
     image: offen/offen:latest
     labels:
       - docker-volume-backup.stop-during-backup=true
+    healthcheck:
+      disable: true
     deploy:
       replicas: 2
       restart_policy:


### PR DESCRIPTION
This is needed since `offen/offen:latest` contains a healthcheck (which would mean we need to wait 2 minutes for all containers to come back to life in the test)