### PR TITLE
Print more error info for minio

### DIFF
--- a/cmd/backup/script.go
+++ b/cmd/backup/script.go
@@ -534,7 +534,7 @@ func (s *script) copyArchive() error {
 			ContentType:  "application/tar+gzip",
 			StorageClass: s.c.AwsStorageClass,
 		}); err != nil {
-			return fmt.Errorf("copyBackup: error uploading backup to remote storage: %w", err)
+			return fmt.Errorf("copyBackup: error uploading backup to remote storage: %w", minio.ToErrorResponse(err))
 		}
 		s.logger.Infof("Uploaded a copy of backup `%s` to bucket `%s`.", s.file, s.c.AwsS3BucketName)
 	}


### PR DESCRIPTION
Could help debugging #134 since Minio should be able to handle retrying...
The [ErrorResponse](https://pkg.go.dev/github.com/minio/minio-go/v7@v7.0.16#ErrorResponse) type contains a lot more info.

Since it's no fix and just helps finding the issue, I created the PR as draft. It may help tracking down Minio issues in the future or help the user with more verbose errors. Feel free to close this if there is no need.