### PR TITLE
Entrypoint permissions can be set on COPY

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,20 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build Docker Image
+        env:
+          DOCKER_BUILDKIT: '1'
         run: docker build . -t offen/docker-volume-backup:test
+
       - name: Run Tests
         working-directory: ./test
         run: |
+          # Stop the buildx container so the tests can make assertions
+          # about the number of running containers
+          docker rm -f $(docker ps -aq)
           export GPG_TTY=$(tty)
           ./test.sh test

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ WORKDIR /root
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /app/cmd/backup/backup /usr/bin/backup
-
-COPY ./entrypoint.sh /root/
-RUN chmod +x entrypoint.sh
+COPY --chmod=755 ./entrypoint.sh /root/
 
 ENTRYPOINT ["/root/entrypoint.sh"]


### PR DESCRIPTION
This removes an unneeded layer from the Docker image.