### PR TITLE
Current Docker client breaks in Go 1.20.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2021 - Offen Authors <hioffen@posteo.de>
 # SPDX-License-Identifier: MPL-2.0
 
-FROM golang:1.20-alpine as builder
+FROM golang:1.20.5-alpine as builder
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Workaround until #241 is ready to merge.