### PR TITLE
Fix storage backends not outputting any info logs

### DIFF
--- a/cmd/backup/script.go
+++ b/cmd/backup/script.go
@@ -127,7 +127,6 @@ func newScript() (*script, error) {
 			s.logger.Warn(fmt.Sprintf("["+context+"] "+msg, params...))
 		case storage.LogLevelError:
 			s.logger.Error(fmt.Sprintf("["+context+"] "+msg, params...))
-		case storage.LogLevelInfo:
 		default:
 			s.logger.Info(fmt.Sprintf("["+context+"] "+msg, params...))
 		}


### PR DESCRIPTION
While implementing a new storage backend for Dropbox, I realized that any `b.Log()` **inside** the storage backends doesn't output anything. Now everything works as expected again.