### PR TITLE
Allow running backup as non-root user in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,13 @@ FROM alpine:3.18
 
 WORKDIR /root
 
+RUN addgroup -g 10001 -S nonroot \
+  && adduser -u 10000 -S -G nonroot -h /home/nonroot nonroot \
+  && chmod a+rw /var/lock
+
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /app/cmd/backup/backup /usr/bin/backup
-COPY --chmod=755 ./entrypoint.sh /root/
+COPY --chmod=755 ./entrypoint.sh /usr/bin
 
-ENTRYPOINT ["/root/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,7 @@ FROM alpine:3.18
 
 WORKDIR /root
 
-RUN addgroup -g 10001 -S nonroot \
-  && adduser -u 10000 -S -G nonroot -h /home/nonroot nonroot \
-  && chmod a+rw /var/lock
-
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates && chmod a+rw /var/lock
 
 COPY --from=builder /app/cmd/backup/backup /usr/bin/backup
 COPY --chmod=755 ./entrypoint.sh /usr/bin

--- a/test/nonroot/Dockerfile
+++ b/test/nonroot/Dockerfile
@@ -1,0 +1,5 @@
+ARG version=canary
+FROM offen/docker-volume-backup:$version
+
+RUN addgroup -g 10001 -S nonroot \
+  && adduser -u 10000 -S -G nonroot -h /home/nonroot nonroot

--- a/test/nonroot/run.sh
+++ b/test/nonroot/run.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+set -e
+
+cd $(dirname $0)
+. ../util.sh
+current_test=$(basename $(pwd))
+
+docker network create test_network
+docker volume create backup_data
+docker volume create app_data
+# This volume is created to test whether empty directories are handled
+# correctly. It is not supposed to hold any data.
+docker volume create empty_data
+
+docker run -d -q \
+  --name minio \
+  --network test_network \
+  --env MINIO_ROOT_USER=test \
+  --env MINIO_ROOT_PASSWORD=test \
+  --env MINIO_ACCESS_KEY=test \
+  --env MINIO_SECRET_KEY=GMusLtUmILge2by+z890kQ \
+  -v backup_data:/data \
+  minio/minio:RELEASE.2020-08-04T23-10-51Z server /data
+
+docker exec minio mkdir -p /data/backup
+
+docker run -d -q \
+  --name offen \
+  --network test_network \
+  -v app_data:/var/opt/offen/ \
+  offen/offen:latest
+
+sleep 10
+
+docker run --rm -q \
+  --network test_network \
+  -v app_data:/backup/app_data \
+  -v empty_data:/backup/empty_data \
+  --env AWS_ACCESS_KEY_ID=test \
+  --env AWS_SECRET_ACCESS_KEY=GMusLtUmILge2by+z890kQ \
+  --env AWS_ENDPOINT=minio:9000 \
+  --env AWS_ENDPOINT_PROTO=http \
+  --env AWS_S3_BUCKET_NAME=backup \
+  --env BACKUP_FILENAME=test.tar.gz \
+  --entrypoint backup \
+  --user nonroot \
+  offen/docker-volume-backup:${TEST_VERSION:-canary}
+
+docker run --rm -q \
+  -v backup_data:/data alpine \
+  ash -c 'tar -xvf /data/backup/test.tar.gz && test -f /backup/app_data/offen.db && test -d /backup/empty_data'
+
+pass "Found relevant files in untared remote backup."
+
+# This test does not stop containers during backup. This is happening on
+# purpose in order to cover this setup as well.
+expect_running_containers "2"

--- a/test/nonroot/run.sh
+++ b/test/nonroot/run.sh
@@ -6,6 +6,11 @@ cd $(dirname $0)
 . ../util.sh
 current_test=$(basename $(pwd))
 
+export BASE_VERSION="${TEST_VERSION:-canary}"
+export TEST_VERSION="${TEST_VERSION:-canary}-with-nonroot"
+
+docker build . -t offen/docker-volume-backup:$TEST_VERSION --build-arg version=$BASE_VERSION
+
 docker network create test_network
 docker volume create backup_data
 docker volume create app_data


### PR DESCRIPTION
This is a proof of concept for #270

Not sure yet whether I really want to merge this.