### PR TITLE
Retry creation of sandbox container

### DIFF
--- a/test/pruning/docker-compose.yml
+++ b/test/pruning/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     volumes:
       - app_data:/backup/app_data:ro
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./local:/archive
+      - ${LOCAL_DIR:-./local}:/archive
 
   offen:
     image: offen/offen:latest

--- a/test/test.sh
+++ b/test/test.sh
@@ -49,16 +49,26 @@ for dir in $(find $find_args | sort); do
 
   if [ -z "$NO_IMAGE_CACHE" ]; then
     docker_run_args="$docker_run_args \
-    -v "${sandbox}_image":/var/lib/docker/image \
-    -v "${sandbox}_overlay2":/var/lib/docker/overlay2"
+      -v "${sandbox}_image":/var/lib/docker/image \
+      -v "${sandbox}_overlay2":/var/lib/docker/overlay2"
   fi
 
   docker run $docker_run_args offen/docker-volume-backup:test-sandbox
 
+  retry_counter=0
   until docker exec $sandbox /bin/sh -c 'docker info' > /dev/null 2>&1; do
+    if [ $retry_counter -gt 20 ]; then
+      echo "Gave up waiting for Docker daemon to become ready after 20 attempts"
+      exit 1
+    fi
+
+    if [ "$(docker inspect $sandbox --format '{{ .State.Running }}')" = "false" ]; then
+      docker run $docker_run_args offen/docker-volume-backup:test-sandbox
+    fi
+
     sleep 0.5
+    retry_counter=$((retry_counter+1))
   done
-  sleep 0.5
 
   docker exec $sandbox /bin/sh -c "docker load -i /cache/image.tar.gz"
   docker exec -e TEST_VERSION=$IMAGE_TAG $sandbox /bin/sh -c "/code/test/$test"

--- a/test/test.sh
+++ b/test/test.sh
@@ -63,6 +63,7 @@ for dir in $(find $find_args | sort); do
     fi
 
     if [ "$(docker inspect $sandbox --format '{{ .State.Running }}')" = "false" ]; then
+      docker rm $sandbox
       docker run $docker_run_args offen/docker-volume-backup:test-sandbox
     fi
 


### PR DESCRIPTION
In CI, tests often seem to hang when the sandbox container fails to be created (the reason for why seems not clear to me, maybe related to https://github.com/moby/moby/issues/12547)