### PR TITLE
Updated Docs subheading mispelling

### DIFF
--- a/docs/how-tos/manual-trigger.md
+++ b/docs/how-tos/manual-trigger.md
@@ -1,5 +1,5 @@
 ---
-title: Trigger a backp manually
+title: Trigger a backup manually
 layout: default
 parent: How Tos
 nav_order: 8


### PR DESCRIPTION
Hello, just a minor fix for the docs heading I picked up on when reading it. Cheers