### PR TITLE
Performance optimization for sshStorage

### DIFF
--- a/internal/storage/ssh/ssh.go
+++ b/internal/storage/ssh/ssh.go
@@ -81,7 +81,11 @@ func NewStorageBackend(opts Config, logFunc storage.Log) (storage.Backend, error
 		return nil, err
 	}
 
-	sftpClient, err := sftp.NewClient(sshClient)
+	sftpClient, err := sftp.NewClient(sshClient,
+																		sftp.UseConcurrentReads(true),
+																		sftp.UseConcurrentWrites(true),
+																		sftp.MaxConcurrentRequestsPerFile(64),
+									 )
 	if err != nil {
 		return nil, fmt.Errorf("NewStorageBackend: error creating sftp client: %w", err)
 	}
@@ -117,7 +121,7 @@ func (b *sshStorage) Copy(file string) error {
 	}
 	defer destination.Close()
 
-	chunk := make([]byte, 1000000)
+	chunk := make([]byte, 1e9)
 	for {
 		num, err := source.Read(chunk)
 		if err == io.EOF {

--- a/internal/storage/ssh/ssh.go
+++ b/internal/storage/ssh/ssh.go
@@ -82,10 +82,10 @@ func NewStorageBackend(opts Config, logFunc storage.Log) (storage.Backend, error
 	}
 
 	sftpClient, err := sftp.NewClient(sshClient,
-																		sftp.UseConcurrentReads(true),
-																		sftp.UseConcurrentWrites(true),
-																		sftp.MaxConcurrentRequestsPerFile(64),
-									 )
+		sftp.UseConcurrentReads(true),
+		sftp.UseConcurrentWrites(true),
+		sftp.MaxConcurrentRequestsPerFile(64),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("NewStorageBackend: error creating sftp client: %w", err)
 	}


### PR DESCRIPTION
Concurrent Writes enabled

Suggested in https://github.com/pkg/sftp/issues/472#issuecomment-930022883

Uploads are 50x faster then before.

4 GiB file takes 5 hours before concurrent writes (~200KB/s). Now it takes like 10 mins (~10MB/s) on my ISP