### PR TITLE
Add method for converting object to JSON in template

### DIFF
--- a/cmd/backup/notifications.go
+++ b/cmd/backup/notifications.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -84,7 +85,8 @@ var templateHelpers = template.FuncMap{
 	"formatBytesBin": func(bytes uint64) string {
 		return formatBytes(bytes, false)
 	},
-	"env": os.Getenv,
+	"env":    os.Getenv,
+	"toJSON": toJSON,
 }
 
 // formatBytes converts an amount of bytes in a human-readable representation
@@ -105,4 +107,13 @@ func formatBytes(b uint64, decimal bool) string {
 		exp++
 	}
 	return fmt.Sprintf(format, float64(b)/float64(div), "kMGTPE"[exp])
+}
+
+func toJSON(v interface{}) string {
+	var bytes []byte
+	var err error
+	if bytes, err = json.MarshalIndent(v, "", "  "); err != nil {
+		return fmt.Sprintf("failed to marshal JSON in notification template: %v", err)
+	}
+	return string(bytes)
 }

--- a/cmd/backup/notifications.go
+++ b/cmd/backup/notifications.go
@@ -86,7 +86,7 @@ var templateHelpers = template.FuncMap{
 		return formatBytes(bytes, false)
 	},
 	"env":          os.Getenv,
-	"toJSON":       toJSON,
+	"toJson":       toJson,
 	"toPrettyJson": toPrettyJson,
 }
 
@@ -110,7 +110,7 @@ func formatBytes(b uint64, decimal bool) string {
 	return fmt.Sprintf(format, float64(b)/float64(div), "kMGTPE"[exp])
 }
 
-func toJSON(v interface{}) string {
+func toJson(v interface{}) string {
 	var bytes []byte
 	var err error
 	if bytes, err = json.Marshal(v); err != nil {

--- a/cmd/backup/notifications.go
+++ b/cmd/backup/notifications.go
@@ -85,8 +85,9 @@ var templateHelpers = template.FuncMap{
 	"formatBytesBin": func(bytes uint64) string {
 		return formatBytes(bytes, false)
 	},
-	"env":    os.Getenv,
-	"toJSON": toJSON,
+	"env":          os.Getenv,
+	"toJSON":       toJSON,
+	"toPrettyJson": toPrettyJson,
 }
 
 // formatBytes converts an amount of bytes in a human-readable representation
@@ -112,8 +113,17 @@ func formatBytes(b uint64, decimal bool) string {
 func toJSON(v interface{}) string {
 	var bytes []byte
 	var err error
-	if bytes, err = json.MarshalIndent(v, "", "  "); err != nil {
+	if bytes, err = json.Marshal(v); err != nil {
 		return fmt.Sprintf("failed to marshal JSON in notification template: %v", err)
+	}
+	return string(bytes)
+}
+
+func toPrettyJson(v interface{}) string {
+	var bytes []byte
+	var err error
+	if bytes, err = json.MarshalIndent(v, "", "  "); err != nil {
+		return fmt.Sprintf("failed to marshal indent JSON in notification template: %v", err)
 	}
 	return string(bytes)
 }

--- a/docs/how-tos/set-up-notifications.md
+++ b/docs/how-tos/set-up-notifications.md
@@ -108,6 +108,7 @@ Some formatting and helper functions are also available:
 * `formatBytesDec`: formats an amount of bytes using powers of 1000 (e.g. `7055258` bytes will be `7.1 MB`)
 * `env`: returns the value of the environment variable of the given key if set
 * `toJSON`: converting object to JSON
+* `toPrettyJson`: converting object to pretty JSON
 
 ## Special characters in notification URLs
 

--- a/docs/how-tos/set-up-notifications.md
+++ b/docs/how-tos/set-up-notifications.md
@@ -107,6 +107,7 @@ Some formatting and helper functions are also available:
 * `formatBytesBin`: formats an amount of bytes using powers of 1024 (e.g. `7055258` bytes will be `6.7 MiB`) 
 * `formatBytesDec`: formats an amount of bytes using powers of 1000 (e.g. `7055258` bytes will be `7.1 MB`)
 * `env`: returns the value of the environment variable of the given key if set
+* `toJSON`: converting object to JSON
 
 ## Special characters in notification URLs
 

--- a/docs/how-tos/set-up-notifications.md
+++ b/docs/how-tos/set-up-notifications.md
@@ -107,7 +107,7 @@ Some formatting and helper functions are also available:
 * `formatBytesBin`: formats an amount of bytes using powers of 1024 (e.g. `7055258` bytes will be `6.7 MiB`) 
 * `formatBytesDec`: formats an amount of bytes using powers of 1000 (e.g. `7055258` bytes will be `7.1 MB`)
 * `env`: returns the value of the environment variable of the given key if set
-* `toJSON`: converting object to JSON
+* `toJson`: converting object to JSON
 * `toPrettyJson`: converting object to pretty JSON
 
 ## Special characters in notification URLs


### PR DESCRIPTION
This adds the `toJSON` template function to notifications, allows the template data to JSON serialized and adds a built in default JSON template (simply `{{ . | toJSON }}`).

Useful if want to format a message in a third-party system according to certain rules.