### PR TITLE
Panic handling does not log reason for script being halted

### DIFF
--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -21,6 +21,9 @@ func main() {
 	defer func() {
 		if pArg := recover(); pArg != nil {
 			if err, ok := pArg.(error); ok {
+				s.logger.Error(
+					fmt.Sprintf("Executing the script encountered a panic: %v", err),
+				)
 				if hookErr := s.runHooks(err); hookErr != nil {
 					s.logger.Error(
 						fmt.Sprintf("An error occurred calling the registered hooks: %s", hookErr),


### PR DESCRIPTION
Working on #333 I noticed the script would silently exit 1 when a nil pointer is dereferenced. This PR adds logging for such cases, making the sudden exit a lot less mysterious.