### PR TITLE
Move cron scheduling inside application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN apk add --no-cache ca-certificates
 COPY --from=builder /app/cmd/backup/backup /usr/bin/backup
 COPY --chmod=755 ./entrypoint.sh /root/
 
-ENTRYPOINT ["/root/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/backup", "--foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN apk add --no-cache ca-certificates
 COPY --from=builder /app/cmd/backup/backup /usr/bin/backup
 COPY --chmod=755 ./entrypoint.sh /root/
 
-ENTRYPOINT ["/usr/bin/backup", "--foreground"]
+ENTRYPOINT ["/usr/bin/backup", "-foreground"]

--- a/cmd/backup/config.go
+++ b/cmd/backup/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	BackupFilenameExpand          bool            `split_words:"true"`
 	BackupLatestSymlink           string          `split_words:"true"`
 	BackupArchive                 string          `split_words:"true" default:"/archive"`
+	BackupCronExpression          string          `split_words:"true" default:"@daily"`
 	BackupRetentionDays           int32           `split_words:"true" default:"-1"`
 	BackupPruningLeeway           time.Duration   `split_words:"true" default:"1m"`
 	BackupPruningPrefix           string          `split_words:"true"`

--- a/cmd/backup/configProvider.go
+++ b/cmd/backup/configProvider.go
@@ -1,0 +1,80 @@
+// Copyright 2021-2022 - Offen Authors <hioffen@posteo.de>
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/joho/godotenv"
+	"github.com/offen/envconfig"
+)
+
+type envProxy func(string) (string, bool)
+
+func loadConfig(lookup envProxy) (*Config, error) {
+	envconfig.Lookup = func(key string) (string, bool) {
+		value, okValue := lookup(key)
+		location, okFile := lookup(key + "_FILE")
+
+		switch {
+		case okValue && !okFile: // only value
+			return value, true
+		case !okValue && okFile: // only file
+			contents, err := os.ReadFile(location)
+			if err != nil {
+				log.Panicf("newScript: failed to read %s! Error: %s", location, err)
+				return "", false
+			}
+			return string(contents), true
+		case okValue && okFile: // both
+			log.Panicf("newScript: both %s and %s are set!", key, key+"_FILE")
+			return "", false
+		default: // neither, ignore
+			return "", false
+		}
+	}
+
+	var c = &Config{}
+	if err := envconfig.Process("", c); err != nil {
+		return nil, fmt.Errorf("newScript: failed to process configuration values: %w", err)
+	}
+
+	return c, nil
+}
+
+func loadEnvVars() (*Config, error) {
+	return loadConfig(os.LookupEnv)
+}
+
+func loadEnvFiles(folder string) ([]*Config, error) {
+	items, err := os.ReadDir(folder)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read files from env folder: %w", err)
+	}
+
+	var cs = make([]*Config, 0)
+	for _, item := range items {
+		if item.IsDir() {
+			log.Println("Skipping directory")
+		} else {
+			envFile, err := godotenv.Read(".env")
+			if err != nil {
+				log.Println("Error reading file: %w", err)
+			}
+			lookup := func(key string) (string, bool) {
+				val, ok := envFile[key]
+				return val, ok
+			}
+			c, err := loadConfig(lookup)
+			if err != nil {
+				log.Println("Error loading config from file: %w", err)
+			}
+			cs = append(cs, c)
+		}
+	}
+
+	return cs, nil
+}

--- a/cmd/backup/config_provider.go
+++ b/cmd/backup/config_provider.go
@@ -38,7 +38,7 @@ func loadConfig(lookup envProxy) (*Config, error) {
 
 	var c = &Config{}
 	if err := envconfig.Process("", c); err != nil {
-		return nil, fmt.Errorf("failed to process configuration values, error: %v", err)
+		return nil, fmt.Errorf("failed to process configuration values, error: %w", err)
 	}
 
 	return c, nil
@@ -54,7 +54,7 @@ func loadEnvFiles(directory string) ([]*Config, error) {
 		if os.IsNotExist(err) {
 			return nil, err
 		}
-		return nil, fmt.Errorf("failed to read files from env directory, error: %v", err)
+		return nil, fmt.Errorf("failed to read files from env directory, error: %w", err)
 	}
 
 	var cs = make([]*Config, 0)
@@ -63,7 +63,7 @@ func loadEnvFiles(directory string) ([]*Config, error) {
 			p := filepath.Join(directory, item.Name())
 			envFile, err := godotenv.Read(p)
 			if err != nil {
-				return nil, fmt.Errorf("error reading config file %s, error: %v", p, err)
+				return nil, fmt.Errorf("error reading config file %s, error: %w", p, err)
 			}
 			lookup := func(key string) (string, bool) {
 				val, ok := envFile[key]
@@ -71,7 +71,7 @@ func loadEnvFiles(directory string) ([]*Config, error) {
 			}
 			c, err := loadConfig(lookup)
 			if err != nil {
-				return nil, fmt.Errorf("error loading config from file %s, error: %v", p, err)
+				return nil, fmt.Errorf("error loading config from file %s, error: %w", p, err)
 			}
 			cs = append(cs, c)
 		}

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -24,7 +24,10 @@ func runBackup(c *Config) {
 	defer func() {
 		s.must(unlock())
 	}()
-	s.must(err)
+	if err != nil {
+		log.Println("Error during locking:", err)
+		return
+	}
 
 	defer func() {
 		if pArg := recover(); pArg != nil {
@@ -37,7 +40,7 @@ func runBackup(c *Config) {
 						fmt.Sprintf("An error occurred calling the registered hooks: %s", hookErr),
 					)
 				}
-				os.Exit(1)
+				return
 			}
 			panic(pArg)
 		}
@@ -49,7 +52,7 @@ func runBackup(c *Config) {
 					err,
 				),
 			)
-			os.Exit(1)
+			return
 		}
 		s.logger.Info("Finished running backup tasks.")
 	}()
@@ -94,7 +97,7 @@ func main() {
 				log.Println("Added cron job with schedule: ", c.BackupCronExpression)
 				_, err := cr.AddFunc(c.BackupCronExpression, func() { runBackup(c) })
 				if err != nil {
-					log.Println("Failed to create cron job with schedule: ", c.BackupCronExpression)
+					log.Println("Failed to create cron job with schedule:", c.BackupCronExpression)
 				}
 			}
 		} else {
@@ -102,7 +105,7 @@ func main() {
 				log.Println("Added cron job with schedule: ", c.BackupCronExpression)
 				_, err := cr.AddFunc(c.BackupCronExpression, func() { runBackup(c) })
 				if err != nil {
-					log.Println("Failed to create cron job with schedule: ", c.BackupCronExpression)
+					log.Println("Failed to create cron job with schedule:", c.BackupCronExpression)
 				}
 			}
 		}

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -113,11 +113,15 @@ func main() {
 
 		cs, err := loadEnvFiles(*envFolder)
 		if err != nil {
-			logger.Warn("could not load config from environment files")
+			if !os.IsNotExist(err) {
+				logger.Error("could not load config from environment files")
+				os.Exit(1)
+			}
 
 			c, err := loadEnvVars()
 			if err != nil {
 				logger.Error("could not load config from environment variables")
+				os.Exit(1)
 			} else {
 				addJob(c)
 			}

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -83,21 +83,27 @@ func main() {
 
 		cr := cron.New()
 
-		c, err := loadEnvVars()
-		if err != nil {
-			log.Println("Could not load config from environment variables")
-		} else {
-			log.Println("Added cron job with schedule: ", c.BackupCronExpression)
-			cr.AddFunc(c.BackupCronExpression, func() { runBackup(c) })
-		}
-
 		cs, err := loadEnvFiles(*envFolder)
 		if err != nil {
 			log.Println("Could not load config from environment files")
+
+			c, err := loadEnvVars()
+			if err != nil {
+				log.Println("Could not load config from environment variables")
+			} else {
+				log.Println("Added cron job with schedule: ", c.BackupCronExpression)
+				_, err := cr.AddFunc(c.BackupCronExpression, func() { runBackup(c) })
+				if err != nil {
+					log.Println("Failed to create cron job with schedule: ", c.BackupCronExpression)
+				}
+			}
 		} else {
 			for _, c := range cs {
 				log.Println("Added cron job with schedule: ", c.BackupCronExpression)
-				cr.AddFunc(c.BackupCronExpression, func() { runBackup(c) })
+				_, err := cr.AddFunc(c.BackupCronExpression, func() { runBackup(c) })
+				if err != nil {
+					log.Println("Failed to create cron job with schedule: ", c.BackupCronExpression)
+				}
 			}
 		}
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -23,9 +23,22 @@ You can populate below template according to your requirements and use it as you
 ```
 ########### BACKUP SCHEDULE
 
-# Backups run on the given cron schedule in `busybox` flavor. If no
-# value is set, `@daily` will be used. If you do not want the cron
-# to ever run, use `0 0 5 31 2 ?`.
+
+# A cron expression represents a set of times, using 5 or 6 space-separated fields.
+#
+# Field name   | Mandatory? | Allowed values  | Allowed special characters
+# ----------   | ---------- | --------------  | --------------------------
+# Seconds      | No         | 0-59            | * / , -
+# Minutes      | Yes        | 0-59            | * / , -
+# Hours        | Yes        | 0-23            | * / , -
+# Day of month | Yes        | 1-31            | * / , - ?
+# Month        | Yes        | 1-12 or JAN-DEC | * / , -
+# Day of week  | Yes        | 0-6 or SUN-SAT  | * / , - ?
+#
+# Month and Day-of-week field values are case insensitive.
+# "SUN", "Sun", and "sun" are equally accepted.
+# If no value is set, `@daily` will be used.
+# If you do not want the cron to ever run, use `0 0 5 31 2 ?`.
 
 # BACKUP_CRON_EXPRESSION="0 2 * * *"
 

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,8 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
+	github.com/robfig/cron/v3 v3.0.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -443,6 +443,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -593,6 +595,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=


### PR DESCRIPTION
Closes #268

Allows the application to take control of the scheduling instead of relying on crond.
- Tries to read config from environment variables
- Reads all the files under `/etc/dockervolumebackup/conf.d` and each creates a new job
- Without `--foreground` flag, returns to old behaviour