### PR TITLE
Exclusive file lock is released prematurely

### DIFF
--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -15,7 +15,9 @@ func main() {
 	}
 
 	unlock, err := s.lock("/var/lock/dockervolumebackup.lock")
-	defer s.must(unlock())
+	defer func() {
+		s.must(unlock())
+	}()
 	s.must(err)
 
 	defer func() {


### PR DESCRIPTION
It seems #263 broke the file lock as it wrapped the `unlock()` call in `must`, which means it would not get deferred anymore.