### PR TITLE
add OCI labels, rework tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
       - name: set Environment Variables
         id: env
         run: |
-          version_tag="${{github.ref_name}}"
           echo "NOW=$(date +'%F %Z %T')" >> $GITHUB_ENV
 
       - name: Docker meta
@@ -32,16 +31,10 @@ jobs:
           # define global behaviour for tags
           flavor: |
             latest=false
-          # generate Docker tags based on the following events/attributes
+          # specify one tag which never gets set, to prevent the tag-attribute being empty, as it will fallback to a default
           tags: |
-            # tag releases as latest, except prerelease tags like `v2.0.0-alpha.x`
-            type=raw,value=latest,enable=${{ !contains(github.ref, 'alpha') }}
             # output v2.42.1-alpha.1 (incl. pre-releases)
-            type=semver,pattern=v{{version}}
-            # output v2.42.1 (excl. pre-releases)
-            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
-            # output v2 
-            type=semver,pattern=v{{major}}
+            type=semver,pattern=v{{version}},enable=false
           labels: |
             org.opencontainers.image.title=${{github.event.repository.name}}
             org.opencontainers.image.description="Backup Docker volumes locally or to any S3, WebDAV, Azure Blob Storage, Dropbox or SSH compatible storage"
@@ -73,7 +66,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-
+      - name: Extract Docker tags
+        id: tags
+        run: |
+          version_tag="${{github.ref_name}}"
+          tags=($version_tag)
+          if [[ "$version_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            # prerelease tags like `v2.0.0-alpha.1` should not be released as `latest` nor `v2`
+            tags+=("latest")
+            tags+=($(echo "$version_tag" | cut -d. -f1))
+          fi
+          releases=""
+          for tag in "${tags[@]}"; do
+            releases="${releases:+$releases,}offen/docker-volume-backup:$tag,ghcr.io/offen/docker-volume-backup:$tag"
+          done
+          echo "releases=$releases" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v5
@@ -81,5 +88,5 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.tags.outputs.releases }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,45 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: set Environment Variables
+        id: env
+        run: |
+          version_tag="${{github.ref_name}}"
+          echo "NOW=$(date +'%F %Z %T')" >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            offen/docker-volume-backup
+            ghcr.io/offen/docker-volume-backup
+          # define global behaviour for tags
+          flavor: |
+            latest=false
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            # tag releases as latest, except prerelease tags like `v2.0.0-alpha.x`
+            type=raw,value=latest,enable=${{ !contains(github.ref, 'alpha') }}
+            # output v2.42.1-alpha.1 (incl. pre-releases)
+            type=semver,pattern=v{{version}}
+            # output v2.42.1 (excl. pre-releases)
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            # output v2 
+            type=semver,pattern=v{{major}}
+          labels: |
+            org.opencontainers.image.title=${{github.event.repository.name}}
+            org.opencontainers.image.description="Backup Docker volumes locally or to any S3, WebDAV, Azure Blob Storage, Dropbox or SSH compatible storage"
+            org.opencontainers.image.vendor=${{github.repository_owner}}
+            org.opencontainers.image.licenses="MPL-2.0"
+            org.opencontainers.image.version=${{github.ref_name}}
+            org.opencontainers.image.created=${{ env.NOW }}
+            org.opencontainers.image.source=${{github.server_url}}/${{github.repository}}
+            org.opencontainers.image.revision=${{github.sha}}
+            org.opencontainers.image.url="https://offen.github.io/docker-volume-backup/"
+            org.opencontainers.image.documentation="https://offen.github.io/docker-volume-backup/"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
@@ -34,26 +73,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Docker tags
-        id: meta
-        run: |
-          version_tag="${{github.ref_name}}"
-          tags=($version_tag)
-          if [[ "$version_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            # prerelease tags like `v2.0.0-alpha.1` should not be released as `latest` nor `v2`
-            tags+=("latest")
-            tags+=($(echo "$version_tag" | cut -d. -f1))
-          fi
-          releases=""
-          for tag in "${tags[@]}"; do
-            releases="${releases:+$releases,}offen/docker-volume-backup:$tag,ghcr.io/offen/docker-volume-backup:$tag"
-          done
-          echo "releases=$releases" >> "$GITHUB_OUTPUT"
+
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: ${{ steps.meta.outputs.releases }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
i'm using [Renovate](https://github.com/renovatebot/renovate) to automatically update dependencies. Renovate (and similar tools as well) support the docker label `org.opencontainers.image.source`, also known as [OCI](https://github.com/opencontainers/image-spec/blob/main/annotations.md) labels to point to sources and add the release notes in the created PRs --> see for example a PR for [tandoor](https://github.com/TandoorRecipes/recipes):

![image](https://github.com/offen/docker-volume-backup/assets/39946364/308de9a4-a0a5-4c50-a89a-48f186ec248c)


I noticed, that this docker-volume-backup currently doesn't leverage these labels and implemented them.
When possible i tried to stick to variables instead of hardcoding informations to keep the package dynamically, in case someone forks and wants to distribute it by himself.

Furthermore i kind of reworked the tagging code and replaced it with the popolur github-action [metadata-action](https://github.com/marketplace/actions/docker-metadata-action).

I stuck with the current logic and implemented a rule, that e.g. the tag `v2.15.4-alpha.2` doens't get the `latest`-tag.

```
# tag releases as latest, except prerelease tags like `v2.0.0-alpha.x`
type=raw,value=latest,enable=${{ !contains(github.ref, 'alpha') }}
```

See the [full documentation](https://github.com/docker/metadata-action?tab=readme-ov-file#typesemver) for the semver-mapping.

I look forward to improvements, reviews and tips!