### PR TITLE
Conditionally run docs-pages-build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,7 @@ name: Deploy Documenation site to GitHub Pages
 on:
   push:
     branches: ['main']
+    paths: ['docs/**']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR changes the workflow to rebuild the docs on github-pages to only run, when content inside the `docs/` folder is changed. Currently with every push on main the docs are rebuilt, even when no changes have been made.