### PR TITLE
Lines from conf files that are comments should not be passed to shell.Expand

### DIFF
--- a/cmd/backup/config_provider.go
+++ b/cmd/backup/config_provider.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/joho/godotenv"
 	"github.com/offen/docker-volume-backup/internal/errwrap"
@@ -136,6 +137,10 @@ func source(path string) (map[string]string, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
 		withExpansion, err := shell.Expand(line, nil)
 		if err != nil {
 			return nil, errwrap.Wrap(err, "error expanding env")

--- a/cmd/backup/config_provider_test.go
+++ b/cmd/backup/config_provider_test.go
@@ -49,6 +49,15 @@ func TestSource(t *testing.T) {
 				"QUX": "yyy",
 			},
 		},
+		{
+			"comments",
+			"testdata/comments.env",
+			false,
+			map[string]string{
+				"BAR": "xxx",
+				"BAZ": "yyy",
+			},
+		},
 	}
 
 	os.Setenv("QUX", "yyy")

--- a/cmd/backup/testdata/comments.env
+++ b/cmd/backup/testdata/comments.env
@@ -1,0 +1,7 @@
+# This is a comment about `why` things are here
+# FOO="${bar:-qux}"
+ # e.g. `backup-$HOSTNAME-%Y-%m-%dT%H-%M-%S.tar.gz`. Expansion happens before`
+
+BAR=xxx
+
+BAZ=$QUX

--- a/test/confd/01backup.env
+++ b/test/confd/01backup.env
@@ -1,2 +1,6 @@
+# This is a comment
+# NOT=$(docker ps -aq)
+# e.g. `backup-$HOSTNAME-%Y-%m-%dT%H-%M-%S.tar.gz`. Expansion happens before`
+
 NAME="$EXPANSION_VALUE"
 BACKUP_CRON_EXPRESSION="*/1 * * * *"


### PR DESCRIPTION
Closes #373 

Currently, all lines in a file from `conf.d` will be passed to `shell.Expand` no matter if they are comments or not. This is not a problem per se, but as `shell.Expand` will refuse to do command substitution (as to prevent execution of arbitrary code), comments containing either `$(cmd)` or ``cmd`` style commands will raise an error.

As there does not seem to be a way to adjust the behavior of `shell.Expand` further, this PR fixes the issue by skipping lines that are obviously comments. 