### PR TITLE
Print stack trace when encountering unexpected panic

### DIFF
--- a/cmd/backup/run_script.go
+++ b/cmd/backup/run_script.go
@@ -6,6 +6,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/offen/docker-volume-backup/internal/errwrap"
 )
@@ -17,6 +18,7 @@ import (
 func runScript(c *Config) (err error) {
 	defer func() {
 		if derr := recover(); derr != nil {
+			fmt.Printf("%s: %s\n", derr, debug.Stack())
 			asErr, ok := derr.(error)
 			if ok {
 				err = errwrap.Wrap(asErr, "unexpected panic running script")


### PR DESCRIPTION
This code is only run on an unexpected panic, which means all graceful error handling mechanisms have failed, rendering the error more mysterious than it should be (see #403). I guess it makes senses to break out of the established logging pipeline and print the stack trace for debugging purposes. 