### PR TITLE
Documentation update for DROPBOX_REMOTE_PATH environment variable

### DIFF
--- a/docs/how-tos/set-up-dropbox.md
+++ b/docs/how-tos/set-up-dropbox.md
@@ -33,5 +33,7 @@ Note: Using the "Generated access token" in the app console is not supported, as
 
 ## Other parameters
 
-Important: If you chose `App folder` access during the creation of your Dropbox app in step 1 above, you can only write in the app's directory!
-This means, that `DROPBOX_REMOTE_PATH` must start with e.g. `/Apps/YOUR_APP_NAME` or `/Apps/YOUR_APP_NAME/some_sub_dir`
+Important: If you chose `App folder` access during the creation of your Dropbox app in step 1 above, `DROPBOX_REMOTE_PATH` will be a relative path under the App folder!
+(_For example, DROPBOX_REMOTE_PATH=/somedir means the backup file will be uploaded to /Apps/myapp/somedir_)
+On the other hand if you chose `Full Dropbox` access, the value for `DROPBOX_REMOTE_PATH` will represent an absolute path inside your Dropbox storage area.
+(_Still considering the same example above, the backup file will be uploaded to /somedir in your Dropbox root_)

--- a/docs/recipes/index.md
+++ b/docs/recipes/index.md
@@ -190,7 +190,7 @@ services:
       DROPBOX_REFRESH_TOKEN: REFRESH_KEY  # replace
       DROPBOX_APP_KEY: APP_KEY  # replace
       DROPBOX_APP_SECRET: APP_SECRET  # replace
-      DROPBOX_REMOTE_PATH: /Apps/my-test-app/some_subdir  # replace
+      DROPBOX_REMOTE_PATH: /somedir  # replace
     volumes:
       - data:/backup/my-app-backup:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
Updated text for explanation of DROPBOX_REMOTE_PATH environment variable usage, accordingly to how the Dropbox App was scoped during creation.

Minor edit to the sample variable value provided for DROPBOX_REMOTE_PATH in the related recipe, for alignment with update done to the how-to.

For more details, please see the discussion on #472 