### PR TITLE
Adds a log message with a plain description of the cron expression.

### DIFF
--- a/cmd/backup/command.go
+++ b/cmd/backup/command.go
@@ -132,6 +132,11 @@ func (c *command) schedule(strategy configStrategy) error {
 				fmt.Sprintf("Scheduled cron expression %s will never run, is this intentional?", config.BackupCronExpression),
 			)
 		}
+		if description, ok := explainCronExpression(config.BackupCronExpression, "en"); ok {
+			c.logger.Info(
+				fmt.Sprintf("The backup will start %s", description),
+			)
+		}
 		c.schedules = append(c.schedules, id)
 	}
 

--- a/cmd/backup/util.go
+++ b/cmd/backup/util.go
@@ -10,9 +10,11 @@ import (
 	"os"
 	"sync"
 	"time"
-
+	"strings"
+	
 	"github.com/offen/docker-volume-backup/internal/errwrap"
 	"github.com/robfig/cron/v3"
+	cron_explain "github.com/lnquy/cron"
 )
 
 var noop = func() error { return nil }
@@ -101,4 +103,67 @@ func checkCronSchedule(expression string) (ok bool) {
 	sched.Next(now) // panics when the cron would never run
 	ok = true
 	return
+}
+
+// explainCronExpression describes the cron expression in plain text.
+func explainCronExpression(expression string, locale string) (description string, ok bool) {
+    predefinedMap := map[string]string{
+        "@yearly":  "0 0 1 1 *",
+        "@annually": "0 0 1 1 *",
+        "@monthly": "0 0 1 * *",
+        "@weekly":  "0 0 * * 0",
+        "@daily":   "0 0 * * *",
+        "@hourly":  "0 * * * *",
+    }
+
+    if translated, exists := predefinedMap[expression]; exists {
+        expression = translated
+    }
+
+    localeMap := map[string]cron_explain.LocaleType{
+        "cs": cron_explain.Locale_cs,
+        "da": cron_explain.Locale_da,
+        "de": cron_explain.Locale_de,
+        "en": cron_explain.Locale_en,
+        "es": cron_explain.Locale_es,
+        "fa": cron_explain.Locale_fa,
+        "fi": cron_explain.Locale_fi,
+        "fr": cron_explain.Locale_fr,
+        "he": cron_explain.Locale_he,
+        "it": cron_explain.Locale_it,
+        "ja": cron_explain.Locale_ja,
+        "ko": cron_explain.Locale_ko,
+        "nb": cron_explain.Locale_nb,
+        "nl": cron_explain.Locale_nl,
+        "pl": cron_explain.Locale_pl,
+        "pt_BR": cron_explain.Locale_pt_BR,
+        "ro": cron_explain.Locale_ro,
+        "ru": cron_explain.Locale_ru,
+        "sk": cron_explain.Locale_sk,
+        "sl": cron_explain.Locale_sl,
+        "sv": cron_explain.Locale_sv,
+        "sw": cron_explain.Locale_sw,
+        "tr": cron_explain.Locale_tr,
+        "uk": cron_explain.Locale_uk,
+        "zh_CN": cron_explain.Locale_zh_CN,
+        "zh_TW": cron_explain.Locale_zh_TW,
+    }
+
+    selectedLocale, exists := localeMap[locale]
+    if !exists {
+        selectedLocale = cron_explain.Locale_en
+    }
+
+    exprDesc, _ := cron_explain.NewDescriptor()
+    desc, err := exprDesc.ToDescription(expression, selectedLocale)
+    if err != nil {
+        return "", false
+    }
+
+    // Ensure the first letter of the description is lowercase
+    if len(desc) > 0 {
+        desc = strings.ToLower(string(desc[0])) + desc[1:]
+    }
+
+    return desc, true
 }

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/lnquy/cron v1.1.1 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.51.0 // indirect
 	go.opentelemetry.io/otel v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leekchan/timeutil v0.0.0-20150802142658-28917288c48d h1:2puqoOQwi3Ai1oznMOsFIbifm6kIfJaLLyYzWD4IzTs=
 github.com/leekchan/timeutil v0.0.0-20150802142658-28917288c48d/go.mod h1:hO90vCP2x3exaSH58BIAowSKvV+0OsY21TtzuFGHON4=
+github.com/lnquy/cron v1.1.1 h1:iaDX1ublgQ9LBhA8l9BVU+FrTE1PPSPAuvAdhgdnXgA=
+github.com/lnquy/cron v1.1.1/go.mod h1:hu2Y7H68/8oKk6T4+K4qdbopbnaP4rGltK3ylWiiDss=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=


### PR DESCRIPTION
This adds [Inquy/cron](https://github.com/lnquy/cron) to log a plain English description of the cron expression.

Examples:

```
time=2024-10-10T20:18:30.765Z level=INFO msg="Successfully scheduled backup from environment with expression @daily"
time=2024-10-10T20:18:30.765Z level=INFO msg="The backup will start at 12:00 AM"

time=2024-10-10T20:17:58.689Z level=INFO msg="Successfully scheduled backup from environment with expression @weekly"
time=2024-10-10T20:17:58.690Z level=INFO msg="The backup will start at 12:00 AM, only on Sunday"

time=2024-10-10T20:18:58.937Z level=INFO msg="Successfully scheduled backup from environment with expression * * * * *"
time=2024-10-10T20:18:58.937Z level=INFO msg="The backup will start every minute"

time=2024-10-10T20:19:21.745Z level=INFO msg="Successfully scheduled backup from environment with expression 0 0 */2 * *"
time=2024-10-10T20:19:21.746Z level=INFO msg="The backup will start at 12:00 AM, every 2 days"

time=2024-10-10T20:20:32.828Z level=INFO msg="Successfully scheduled backup from environment with expression 11 1 */2 * MON-WED"
time=2024-10-10T20:20:32.829Z level=INFO msg="The backup will start at 01:11 AM, every 2 days, Monday through Wednesday"
```

This does not support the `@every` syntax, in that case it will just refrain from printing anything extra than it does now.
