### PR TITLE
Update stop-containers-during-backup.md

### DIFF
--- a/docs/how-tos/stop-containers-during-backup.md
+++ b/docs/how-tos/stop-containers-during-backup.md
@@ -31,7 +31,7 @@ services:
       BACKUP_STOP_DURING_BACKUP_LABEL: service1
     volumes:
       - data:/backup/my-app-backup:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   data:


### PR DESCRIPTION
Read-only for /var/run/docker.sock:/var/run/docker.sock is wrong. Otherwise, a stop of different containers may not be possible.

Here is it all right: https://offen.github.io/docker-volume-backup/recipes/#using-mariadb-dumpmysqldump-to-prepare-the-backup