### PR TITLE
Ensure destination exists when using SSH storage

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -278,6 +278,7 @@ The values for each key currently match its default.
 # ---
 
 # The Directory to place the backups to on the SSH server.
+# If the directory does not exist, it will be created automatically.
 # Example: "/home/user/backups"
 
 # SSH_REMOTE_PATH=""

--- a/internal/storage/ssh/ssh.go
+++ b/internal/storage/ssh/ssh.go
@@ -4,6 +4,7 @@
 package ssh
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"

--- a/internal/storage/ssh/ssh.go
+++ b/internal/storage/ssh/ssh.go
@@ -107,6 +107,10 @@ func (b *sshStorage) Name() string {
 
 // Copy copies the given file to the SSH storage backend.
 func (b *sshStorage) Copy(file string) (returnErr error) {
+	if err := b.sftpClient.MkdirAll(b.DestinationPath); err != nil {
+		return errwrap.Wrap(err, "error ensuring destination directory")
+	}
+
 	source, err := os.Open(file)
 	_, name := path.Split(file)
 	if err != nil {
@@ -170,6 +174,10 @@ func (b *sshStorage) Copy(file string) (returnErr error) {
 func (b *sshStorage) Prune(deadline time.Time, pruningPrefix string) (*storage.PruneStats, error) {
 	candidates, err := b.sftpClient.ReadDir(b.DestinationPath)
 	if err != nil {
+		// If directory doesn't exist yet, nothing to prune
+		if errors.Is(err, os.ErrNotExist) {
+			return &storage.PruneStats{}, nil
+		}
 		return nil, errwrap.Wrap(err, "error reading directory")
 	}
 


### PR DESCRIPTION
When using SSH storage, ensure destination directory exists.