### PR TITLE
Add checks for tools in test suite

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -10,14 +10,12 @@ tarball="$(mktemp -d)/image.tar.gz"
 compose_profile="default"
 find_bin="find"
 
-require_cmd() {
-  if ! command -v "$1" >/dev/null 2>&1; then
-    echo "[test:setup:fail] Required command '$1' not found in PATH."
-    exit 1
-  fi
-}
 
-require_cmd docker
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[test:setup:fail] Required command 'docker' not found in PATH."
+  exit 1
+fi
+
 if ! docker compose version >/dev/null 2>&1; then
   echo "[test:setup:fail] Docker Compose v2 is required ('docker compose')."
   exit 1


### PR DESCRIPTION
This PR aims to make the test suite easier to use.

- Adds optional `gfind` support for macos users
- Checks if tools are present early and fails with helpful error messages if not