### PR TITLE
Make test suite work on macos

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -29,7 +29,7 @@ if [ ! -z "$MATCH_PATTERN" ]; then
   find_args="$find_args -name $MATCH_PATTERN"
 fi
 
-for dir in $(find $find_args | sort); do
+for dir in $(find . $find_args | sort); do
   dir=$(echo $dir | cut -c 3-)
   echo "################################################"
   echo "Now running ${dir}"
@@ -58,7 +58,7 @@ for dir in $(find $find_args | sort); do
     docker exec $svc /bin/sh -c "docker load -i /cache/image.tar.gz"
   done
 
-  for executable in $(find $dir -type f -executable | sort); do
+  for executable in $(find $dir -type f -perm -u+x | sort); do
     context="manager"
     if [ -f "$executable.context" ]; then
         context=$(cat "$executable.context")


### PR DESCRIPTION
## AI disclaimer

This PR was partly created with codex cli.
  
## What changed

  - Add an explicit start path to the top-level directory scan: find . $find_args
    so BSD/macOS find doesn’t treat -mindepth/-maxdepth as illegal options when
    no path is provided.
  - Replace GNU-only -executable with portable -perm -u+x for runnable test
    discovery.

  ## Why

  - BSD/macOS find requires a path argument; without it, options like -mindepth
    are parsed as invalid (BSD find(1) synopsis and option descriptions). GNU
    find allows no path, so this only fails on BSD/macOS.
  - -executable is documented in GNU findutils but is not listed in BSD find(1).
    -perm -u+x is supported by both and checks the user execute bit.

  ## Flag details (with docs)

  - . start path
      - BSD find(1) synopsis requires a path before expressions: https://
        man.freebsd.org/cgi/man.cgi?query=find&sektion=1
  - -mindepth 1 / -maxdepth 1
      - GNU: https://www.gnu.org/software/findutils/manual/html_node/find_html/
        Directories.html
      - BSD: https://man.freebsd.org/cgi/man.cgi?query=find&sektion=1
  - -type d / -type f
      - GNU: https://www.gnu.org/software/findutils/manual/html_node/find_html/
        Type.html
      - BSD: https://man.freebsd.org/cgi/man.cgi?query=find&sektion=1
  - -name <pattern>
      - GNU: https://www.gnu.org/software/findutils/manual/html_node/find_html/
        Base-Name-Patterns.html
      - BSD: https://man.freebsd.org/cgi/man.cgi?query=find&sektion=1
  - -perm -u+x
      - GNU -perm semantics: https://www.gnu.org/software/findutils/manual/
        html_node/find_html/Mode-Bits.html
      - BSD -perm semantics: https://man.freebsd.org/cgi/man.cgi?
        query=find&sektion=1
  - GNU-only -executable (reason for change)
      - GNU doc: https://www.gnu.org/software/findutils/manual/html_node/
        find_html/Mode-Bits.html
      - BSD find(1) does not list -executable: https://man.freebsd.org/cgi/
        man.cgi?query=find&sektion=1

  ## Behavior

  - Directory discovery still targets only direct child directories.
  - Script discovery still targets executable test scripts; the criteria now work
    on both GNU and BSD/macOS..