### PR TITLE
refactor: for 'docker compose up' use built-in flag --wait instead of 'sleep 5'

### DIFF
--- a/test/age-passphrase/run.sh
+++ b/test/age-passphrase/run.sh
@@ -8,8 +8,7 @@ current_test=$(basename "$(pwd)")
 
 export LOCAL_DIR="$(mktemp -d)"
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 

--- a/test/age-publickey/run.sh
+++ b/test/age-publickey/run.sh
@@ -18,8 +18,7 @@ PK_C="$(cat $LOCAL_DIR/id_ed25519.pub)"
 
 export BACKUP_AGE_PUBLIC_KEYS="$PK_A,$PK_B,$PK_C"
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 

--- a/test/azure/run.sh
+++ b/test/azure/run.sh
@@ -15,9 +15,7 @@ download_az () {
     az storage blob download -f /dump/$1.tar.gz -c test-container -n path/to/backup/$1.tar.gz
 }
 
-docker compose up -d --quiet-pull
-
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 
@@ -38,8 +36,7 @@ rm "$LOCAL_DIR/test.tar.gz"
 
 # The second part of this test checks if backups get deleted when the retention
 # is set to 0 days (which it should not as it would mean all backups get deleted)
-BACKUP_RETENTION_DAYS="0" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="0" docker compose up -d --wait
 
 docker compose exec backup backup
 
@@ -52,8 +49,7 @@ pass "Remote backups have not been deleted."
 # The third part of this test checks if old backups get deleted when the retention
 # is set to 7 days (which it should)
 
-BACKUP_RETENTION_DAYS="7" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="7" docker compose up -d --wait
 
 info "Create first backup with no prune"
 docker compose exec backup backup
@@ -67,8 +63,7 @@ rm "$LOCAL_DIR/test.tar.gz"
 back_date="$(date "+%Y-%m-%dT%H:%M:%S%z" -d "14 days ago" | rev | cut -c 3- | rev):00"
 jq --arg back_date "$back_date" '(.collections[] | select(.name=="$BLOBS_COLLECTION$") | .data[] | select(.name=="path/to/backup/test-old.tar.gz") | .properties.creationTime = $back_date)' "$DATA_DIR/__azurite_db_blob__.json" | sponge "$DATA_DIR/__azurite_db_blob__.json"
 
-docker compose up -d
-sleep 5
+docker compose up -d --wait
 
 info "Create second backup and prune"
 docker compose exec backup backup

--- a/test/certs/run.sh
+++ b/test/certs/run.sh
@@ -26,8 +26,7 @@ openssl x509 -req -passin pass:test \
 
 openssl x509 -in "$CERT_DIR/minio.crt" -noout -text
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 

--- a/test/commands/01compose.sh
+++ b/test/commands/01compose.sh
@@ -9,8 +9,7 @@ current_test=$(basename $(pwd))
 export LOCAL_DIR=$(mktemp -d)
 export TMP_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 30 # mariadb likes to take a bit before responding
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 

--- a/test/dropbox/run.sh
+++ b/test/dropbox/run.sh
@@ -11,8 +11,7 @@ cp user_v2.yaml $SPEC_FILE
 sed -i 's/SERVER_MODIFIED_1/'"$(date "+%Y-%m-%dT%H:%M:%SZ")/g" $SPEC_FILE
 sed -i 's/SERVER_MODIFIED_2/'"$(date "+%Y-%m-%dT%H:%M:%SZ" -d "14 days ago")/g" $SPEC_FILE
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 logs=$(docker compose exec -T backup backup)
 
@@ -29,8 +28,7 @@ fi
 
 # The second part of this test checks if backups get deleted when the retention
 # is set to 0 days (which it should not as it would mean all backups get deleted)
-BACKUP_RETENTION_DAYS="0" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="0" docker compose up -d --wait
 
 logs=$(docker compose exec -T backup backup)
 
@@ -43,8 +41,7 @@ fi
 
 # The third part of this test checks if old backups get deleted when the retention
 # is set to 7 days (which it should)
-BACKUP_RETENTION_DAYS="7" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="7" docker compose up -d --wait
 
 info "Create second backup and prune"
 logs=$(docker compose exec -T backup backup)

--- a/test/extend/run.sh
+++ b/test/extend/run.sh
@@ -13,8 +13,7 @@ export TEST_VERSION="${TEST_VERSION:-canary}-with-rsync"
 
 docker build . -t offen/docker-volume-backup:$TEST_VERSION --build-arg version=$BASE_VERSION
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 

--- a/test/googledrive/run.sh
+++ b/test/googledrive/run.sh
@@ -11,8 +11,7 @@ cp googledrive_v3.yaml $SPEC_FILE
 sed -i 's/CREATED_TIME_1/'"$(date "+%Y-%m-%dT%H:%M:%SZ")/g" $SPEC_FILE
 sed -i 's/CREATED_TIME_2/'"$(date "+%Y-%m-%dT%H:%M:%SZ" -d "14 days ago")/g" $SPEC_FILE
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 logs=$(docker compose exec backup backup | tee /dev/stderr)
 
@@ -28,8 +27,7 @@ fi
 
 # The second part of this test checks if backups get deleted when the retention
 # is set to 0 days (which it should not as it would mean all backups get deleted)
-BACKUP_RETENTION_DAYS="0" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="0" docker compose up -d --wait
 
 logs=$(docker compose exec -T backup backup | tee /dev/stderr)
 
@@ -41,8 +39,7 @@ fi
 
 # The third part of this test checks if old backups get deleted when the retention
 # is set to 7 days (which it should)
-BACKUP_RETENTION_DAYS="7" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="7" docker compose up -d --wait
 
 info "Create second backup and prune"
 

--- a/test/gpg-asym/run.sh
+++ b/test/gpg-asym/run.sh
@@ -24,8 +24,7 @@ EOF
 
 gpg --export --armor --batch --yes --pinentry-mode loopback --passphrase $PASSPHRASE --output $KEY_DIR/public_key.asc
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 

--- a/test/gpg/run.sh
+++ b/test/gpg/run.sh
@@ -8,8 +8,7 @@ current_test=$(basename $(pwd))
 
 export LOCAL_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 

--- a/test/ignore/run.sh
+++ b/test/ignore/run.sh
@@ -8,8 +8,8 @@ current_test=$(basename $(pwd))
 
 export LOCAL_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
+
 docker compose exec backup backup
 
 TMP_DIR=$(mktemp -d)

--- a/test/local/run.sh
+++ b/test/local/run.sh
@@ -8,8 +8,7 @@ current_test=$(basename $(pwd))
 
 export LOCAL_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 # A symlink for a known file in the volume is created so the test can check
 # whether symlinks are preserved on backup.
@@ -41,8 +40,7 @@ pass "Found symlink to latest version in local backup."
 
 # The second part of this test checks if backups get deleted when the retention
 # is set to 0 days (which it should not as it would mean all backups get deleted)
-BACKUP_RETENTION_DAYS="0" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="0" docker compose up -d --wait
 
 docker compose exec backup backup
 
@@ -54,8 +52,7 @@ pass "Local backups have not been deleted."
 # The third part of this test checks if old backups get deleted when the retention
 # is set to 7 days (which it should)
 
-BACKUP_RETENTION_DAYS="7" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="7" docker compose up -d --wait
 
 info "Create first backup with no prune"
 docker compose exec backup backup

--- a/test/lock/run.sh
+++ b/test/lock/run.sh
@@ -8,8 +8,7 @@ current_test=$(basename $(pwd))
 
 export LOCAL_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 ec=0
 

--- a/test/no-restart/run.sh
+++ b/test/no-restart/run.sh
@@ -8,8 +8,7 @@ current_test=$(basename $(pwd))
 
 export LOCAL_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 

--- a/test/nonroot/run.sh
+++ b/test/nonroot/run.sh
@@ -8,8 +8,7 @@ current_test=$(basename $(pwd))
 
 export LOCAL_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose logs backup
 

--- a/test/notifications/run.sh
+++ b/test/notifications/run.sh
@@ -8,8 +8,7 @@ current_test=$(basename $(pwd))
 
 export LOCAL_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 GOTIFY_TOKEN=$(curl -sSLX POST -H 'Content-Type: application/json' -d '{"name":"test"}' http://admin:custom@localhost:8080/application | jq -r '.token')
 info "Set up Gotify application using token $GOTIFY_TOKEN"

--- a/test/ownership/run.sh
+++ b/test/ownership/run.sh
@@ -9,8 +9,7 @@ current_test=$(basename $(pwd))
 
 export LOCAL_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 

--- a/test/proxy/01compose.sh
+++ b/test/proxy/01compose.sh
@@ -8,8 +8,7 @@ current_test=$(basename $(pwd))
 
 export LOCAL_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 # The default configuration in docker-compose.yml should
 # successfully create a backup.
@@ -25,8 +24,7 @@ fi
 pass "Found relevant archive file."
 
 # Disabling POST should make the backup run fail
-ALLOW_POST="0" docker compose up -d
-sleep 5
+ALLOW_POST="0" docker compose up -d --wait
 
 set +e
 docker compose exec backup backup

--- a/test/pruning/run.sh
+++ b/test/pruning/run.sh
@@ -11,8 +11,7 @@ current_test=$(basename $(pwd))
 
 export LOCAL_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 
@@ -29,8 +28,7 @@ docker run --rm \
 
 # Skip s3 backend from prune
 
-docker compose up -d
-sleep 5
+docker compose up -d --wait
 
 info "Create backup with no prune for s3 backend"
 docker compose exec backup backup
@@ -52,8 +50,7 @@ pass "Old remote backup has been pruned locally, skipped S3 backend is untouched
 
 touch -r "$LOCAL_DIR/test-hostnametoken.tar.gz" -d "14 days ago" "$LOCAL_DIR/test-hostnametoken-old.tar.gz"
 
-docker compose up -d
-sleep 5
+docker compose up -d --wait
 
 info "Create backup with no prune for both backends"
 docker compose exec -e BACKUP_SKIP_BACKENDS_FROM_PRUNE="s3,local" backup backup

--- a/test/s3/run.sh
+++ b/test/s3/run.sh
@@ -6,8 +6,7 @@ cd "$(dirname "$0")"
 . ../util.sh
 current_test=$(basename $(pwd))
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 
@@ -24,8 +23,7 @@ pass "Found relevant files in untared remote backups."
 
 # The second part of this test checks if backups get deleted when the retention
 # is set to 0 days (which it should not as it would mean all backups get deleted)
-BACKUP_RETENTION_DAYS="0" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="0" docker compose up -d --wait
 
 docker compose exec backup backup
 
@@ -39,8 +37,7 @@ pass "Remote backups have not been deleted."
 # The third part of this test checks if old backups get deleted when the retention
 # is set to 7 days (which it should)
 
-BACKUP_RETENTION_DAYS="7" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="7" docker compose up -d --wait
 
 info "Create first backup with no prune"
 docker compose exec backup backup

--- a/test/ssh/run.sh
+++ b/test/ssh/run.sh
@@ -10,8 +10,7 @@ export KEY_DIR=$(mktemp -d)
 
 ssh-keygen -t rsa -m pem -b 4096 -N "test1234" -f "$KEY_DIR/id_rsa" -C "docker-volume-backup@local"
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 
@@ -28,8 +27,7 @@ pass "Found relevant files in decrypted and untared remote backups."
 
 # The second part of this test checks if backups get deleted when the retention
 # is set to 0 days (which it should not as it would mean all backups get deleted)
-BACKUP_RETENTION_DAYS="0" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="0" docker compose up -d --wait
 
 docker compose exec backup backup
 
@@ -43,8 +41,7 @@ pass "Remote backups have not been deleted."
 # The third part of this test checks if old backups get deleted when the retention
 # is set to 7 days (which it should)
 
-BACKUP_RETENTION_DAYS="7" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="7" docker compose up -d --wait
 
 info "Create first backup with no prune"
 docker compose exec backup backup

--- a/test/tar/run.sh
+++ b/test/tar/run.sh
@@ -8,8 +8,7 @@ current_test=$(basename $(pwd))
 
 export LOCAL_DIR=$(mktemp -d)
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 

--- a/test/webdav/run.sh
+++ b/test/webdav/run.sh
@@ -6,8 +6,7 @@ cd "$(dirname "$0")"
 . ../util.sh
 current_test=$(basename $(pwd))
 
-docker compose up -d --quiet-pull
-sleep 5
+docker compose up -d --quiet-pull --wait
 
 docker compose exec backup backup
 
@@ -24,8 +23,7 @@ pass "Found relevant files in untared remote backup."
 
 # The second part of this test checks if backups get deleted when the retention
 # is set to 0 days (which it should not as it would mean all backups get deleted)
-BACKUP_RETENTION_DAYS="0" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="0" docker compose up -d --wait
 
 docker compose exec backup backup
 
@@ -39,8 +37,7 @@ pass "Remote backups have not been deleted."
 # The third part of this test checks if old backups get deleted when the retention
 # is set to 7 days (which it should)
 
-BACKUP_RETENTION_DAYS="7" docker compose up -d
-sleep 5
+BACKUP_RETENTION_DAYS="7" docker compose up -d --wait
 
 info "Create first backup with no prune"
 docker compose exec backup backup


### PR DESCRIPTION
## Changes
Changes in run.sh files from test/

Just use built-in flag --wait for `docker compose up`  instead of `sleep 5` - it's more reliable in case if containers won't be up after 5 seconds

@m90 fyi