### PR TITLE
Lock gotify server to v2

### DIFF
--- a/test/notifications/docker-compose.yml
+++ b/test/notifications/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - app_data:/var/opt/offen
 
   gotify:
-    image: gotify/server
+    image: gotify/server:2.9
     ports:
       - 8080:80
     environment:


### PR DESCRIPTION
`gotify/server` was using latest, which recently started to pull in breaking changes. I guess it's fine to stick to v2 here until v3 features are actually needed.