### PR TITLE
Support tencent cloud COS

### DIFF
--- a/cmd/backup/config.go
+++ b/cmd/backup/config.go
@@ -311,6 +311,17 @@ func (c *Config) resolve() (reset func() error, warnings []string, err error) {
 	}
 	c.BackupFilename = bf.String()
 
+	awsS3BucketLookupValidSet := map[string]struct{}{
+		"auto":    {},
+		"dns":     {},
+		"virtual": {},
+		"path":    {},
+	}
+	if _, ok := awsS3BucketLookupValidSet[c.AwsS3BucketLookup]; !ok {
+		err = errwrap.Wrap(nil, fmt.Sprintf("unknown AWS_S3_BUCKET_LOOKUP %s", c.AwsS3BucketLookup))
+		return
+	}
+
 	if c.AzureStorageEndpoint != "" {
 		endpointTemplate, tErr := template.New("endpoint").Parse(c.AzureStorageEndpoint)
 		if tErr != nil {

--- a/cmd/backup/config.go
+++ b/cmd/backup/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	AwsSecretAccessKey                   string          `split_words:"true"`
 	AwsIamRoleEndpoint                   string          `split_words:"true"`
 	AwsPartSize                          int64           `split_words:"true"`
+	AwsS3BucketLookup                    string          `split_words:"true" default:"auto"`
 	BackupCompression                    CompressionType `split_words:"true" default:"gz"`
 	GzipParallelism                      WholeNumber     `split_words:"true" default:"1"`
 	BackupSources                        string          `split_words:"true" default:"/backup"`

--- a/cmd/backup/script.go
+++ b/cmd/backup/script.go
@@ -159,6 +159,7 @@ func (s *script) init() error {
 			BucketName:       s.c.AwsS3BucketName,
 			StorageClass:     s.c.AwsStorageClass,
 			CACert:           s.c.AwsEndpointCACert.Cert,
+			BucketLookup:     s.c.AwsS3BucketLookup,
 			PartSize:         s.c.AwsPartSize,
 		}
 		s3Backend, err := s3.NewStorageBackend(s3Config, logFunc)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -237,6 +237,16 @@ If you need to confirm what the container actually loaded, see [Show loaded conf
 
 # AWS_PART_SIZE="16"
 
+# ---
+
+# Controls the bucket lookup style used by the S3 client. Possible values:
+# - "auto": use virtual-host style only for AWS S3, GCS, and Aliyun OSS
+# - "dns" (or "virtual"): force virtual-host style (e.g. Tencent COS)
+# - "path": force path style
+# Defaults to "auto".
+
+# AWS_S3_BUCKET_LOOKUP="auto"
+
 ########### WEBDAV STORAGE
 
 # The URL of the remote WebDAV server

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -38,6 +38,7 @@ type Config struct {
 	BucketName       string
 	StorageClass     string
 	PartSize         int64
+	BucketLookup     string
 	CACert           *x509.Certificate
 }
 
@@ -59,6 +60,16 @@ func NewStorageBackend(opts Config, logFunc storage.Log) (storage.Backend, error
 	options := minio.Options{
 		Creds:  creds,
 		Secure: opts.EndpointProto == "https",
+	}
+	switch opts.BucketLookup {
+	case "dns", "virtual":
+		options.BucketLookup = minio.BucketLookupDNS
+	case "path":
+		options.BucketLookup = minio.BucketLookupPath
+	case "", "auto":
+		options.BucketLookup = minio.BucketLookupAuto
+	default:
+		return nil, errwrap.Wrap(nil, fmt.Sprintf("unknown AWS_S3_BUCKET_LOOKUP value: %s", opts.BucketLookup))
 	}
 
 	transport, err := minio.DefaultTransport(true)

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -66,7 +66,7 @@ func NewStorageBackend(opts Config, logFunc storage.Log) (storage.Backend, error
 		options.BucketLookup = minio.BucketLookupDNS
 	case "path":
 		options.BucketLookup = minio.BucketLookupPath
-	case "", "auto":
+	case "auto":
 		options.BucketLookup = minio.BucketLookupAuto
 	default:
 		return nil, errwrap.Wrap(nil, fmt.Sprintf("unknown AWS_S3_BUCKET_LOOKUP value: %s", opts.BucketLookup))


### PR DESCRIPTION
Some S3 providers (e.g. Tencent Cloud COS) requires custom bucket lookup method. This PR adds a new env var named `AWS_S3_BUCKET_LOOKUP` to support this feature.

I've confirmed that it works with the following setup:

- Image: `ghcr.io/sainnhe/docker-volume-backup:v2`
- Envs:

```
AWS_ENDPOINT="cos.ap-guangzhou.myqcloud.com"
AWS_ENDPOINT_PROTO="https"
AWS_S3_BUCKET_LOOKUP="dns"
AWS_S3_BUCKET_NAME="xxx"
AWS_ACCESS_KEY_ID="AKxxx"
AWS_SECRET_ACCESS_KEY="xxx"
```